### PR TITLE
feat: add field editing to query editor

### DIFF
--- a/src/components/query/query.css
+++ b/src/components/query/query.css
@@ -396,3 +396,42 @@
     display: none;
 }
 
+/* ============================================================
+   Editable Table Styles
+   ============================================================ */
+
+.query-results-editable td {
+    padding: 4px 6px;
+}
+
+.query-field-input {
+    width: 100%;
+    padding: 4px 6px;
+    border: 1px solid var(--border-color);
+    border-radius: 3px;
+    font-size: 13px;
+    font-family: inherit;
+    background: white;
+    box-sizing: border-box;
+}
+
+.query-field-input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 1px var(--primary-color) inset;
+}
+
+.query-field-input[type="checkbox"] {
+    width: auto;
+    cursor: pointer;
+}
+
+.query-results-table td.modified {
+    background-color: #fff4e5;
+    border-left: 3px solid #ff9500;
+}
+
+.query-results-table td.modified .query-field-input {
+    background-color: #fff4e5;
+}
+

--- a/src/components/query/query.html
+++ b/src/components/query/query.html
@@ -18,6 +18,10 @@
                 <input type="checkbox" class="query-tooling-checkbox">
                 Tooling API
             </label>
+            <label class="btn-icon-checkbox">
+                <input type="checkbox" class="query-editing-checkbox">
+                Enable Editing
+            </label>
         </button-icon>
     </div>
     <div class="card-body">
@@ -39,6 +43,7 @@
         </div>
         <button-icon class="query-results-btn" icon="&#8942;" title="Options">
             <button class="btn-icon-option query-export-btn" disabled>Export CSV</button>
+            <button class="btn-icon-option query-save-btn" disabled>Save Changes</button>
         </button-icon>
     </div>
     <div class="card-body query-card-body">


### PR DESCRIPTION
Implements field editing in the query editor with automatic editability detection, field-type-aware inputs, and bulk save functionality.

Fixes #5

Generated with [Claude Code](https://claude.ai/code)