### PR TITLE
Fix history button event listeners in query and apex tabs

### DIFF
--- a/src/components/apex/apex-tab.js
+++ b/src/components/apex/apex-tab.js
@@ -75,7 +75,7 @@ for (Account acc : accounts) {
         this.codeEditor.addEventListener('execute', () => this.executeApex());
 
         // History modal
-        this.historyBtn.addEventListener('toggle', () => this.historyModal.toggle());
+        this.historyBtn.addEventListener('click', () => this.historyModal.toggle());
 
         // History dropdown tab switching
         this.dropdownTabs.forEach(tab => {

--- a/src/components/query/query-tab.js
+++ b/src/components/query/query-tab.js
@@ -132,7 +132,7 @@ LIMIT 10`);
         this.editor.addEventListener('execute', () => this.executeQuery());
 
         // History modal
-        this.historyBtn.addEventListener('toggle', () => this.historyModal.toggle());
+        this.historyBtn.addEventListener('click', () => this.historyModal.toggle());
 
         // History tab switching
         this.dropdownTabs.forEach(tab => {


### PR DESCRIPTION
After button-icon refactoring, simple buttons without menus dispatch 'click' events instead of 'toggle' events. Updated event listeners in both query-tab and apex-tab to listen for 'click' events to restore modal functionality.

Fixes #22

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/bct8925/sftools/actions/runs/20905401984