### PR TITLE
Apply monospace font to query results

### DIFF
--- a/src/components/query/query.css
+++ b/src/components/query/query.css
@@ -372,6 +372,10 @@
     white-space: nowrap;
 }
 
+.query-results-table td {
+    font-family: 'SF Mono', Monaco, Consolas, monospace;
+}
+
 .query-results-table th {
     border-bottom: 0;
     background-color: #f8f9fa;
@@ -470,6 +474,10 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.query-subquery-table td {
+    font-family: 'SF Mono', Monaco, Consolas, monospace;
 }
 
 .query-subquery-table th {


### PR DESCRIPTION
Fixes #28

Applied monospace font styling to query results table cells for improved readability.

## Changes
- Added monospace font-family to main query results table cells
- Applied same styling to subquery table cells for consistency

Generated with [Claude Code](https://claude.ai/code)