### PR TITLE
Closes #33: Fix alignment of refresh and remove buttons in query tabs

### DIFF
--- a/src/components/query/query-tab.js
+++ b/src/components/query/query-tab.js
@@ -762,7 +762,7 @@ LIMIT 10`);
 
             const refreshBtn = document.createElement('button');
             refreshBtn.className = 'query-tab-refresh';
-            refreshBtn.innerHTML = '&#x21bb;';
+            refreshBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"></path><path d="M1 20v-6h6"></path><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>';
             refreshBtn.title = 'Refresh';
             refreshBtn.addEventListener('click', (e) => {
                 e.stopPropagation();
@@ -771,7 +771,7 @@ LIMIT 10`);
 
             const closeBtn = document.createElement('button');
             closeBtn.className = 'query-tab-close';
-            closeBtn.innerHTML = '&times;';
+            closeBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M4.646 4.646a.5.5 0 01.708 0L8 7.293l2.646-2.647a.5.5 0 01.708.708L8.707 8l2.647 2.646a.5.5 0 01-.708.708L8 8.707l-2.646 2.647a.5.5 0 01-.708-.708L7.293 8 4.646 5.354a.5.5 0 010-.708z"/></svg>';
             closeBtn.title = 'Close';
             closeBtn.addEventListener('click', (e) => {
                 e.stopPropagation();

--- a/src/components/query/query.css
+++ b/src/components/query/query.css
@@ -298,12 +298,15 @@
 .query-tab-close {
     background: none;
     border: none;
-    padding: 0 2px;
-    font-size: 14px;
+    padding: 2px;
     cursor: pointer;
     opacity: 0.6;
     color: inherit;
     line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
 }
 
 .query-tab-refresh:hover,


### PR DESCRIPTION
Closes #33

[Image showing misalignment]

The text, refresh icon, and "x" icon should align better vertically

---

**Changes:**
- Replaced text character icons (↻ and ×) with proper SVG icons
- Used stroke-based refresh icon matching the settings UI for consistency
- Applied flexbox alignment for consistent vertical centering
- Removed font-size and height constraints (not needed with SVG)

**Testing:**
- Verified alignment looks correct in query result tabs
- Refresh and close buttons now properly align with tab label text

---

This PR was created by the /issue-triage command.