### PR TITLE
Closes #25: Restore query to editor when clicking result tab

### DIFF
--- a/src/components/query/query-tab.js
+++ b/src/components/query/query-tab.js
@@ -668,6 +668,13 @@ LIMIT 10`);
 
     switchToTab(tabId) {
         this.activeTabId = tabId;
+
+        // Restore the query to the editor when switching tabs
+        const tabData = this.getTabDataById(tabId);
+        if (tabData && tabData.query) {
+            this.editor.setValue(tabData.query);
+        }
+
         this.renderTabs();
         this.renderResults();
         // Clear search when switching tabs


### PR DESCRIPTION
Closes #25

When users click on a query result tab, the original query is now restored to the Monaco editor.

## Changes

- Modified `switchToTab()` method in `src/components/query/query-tab.js`
- Added logic to restore `tabData.query` to the editor when switching tabs
- Makes it easier to view, edit, and re-run previous queries

## Implementation

The query was already stored in `tabData.query` for each tab, so the implementation was straightforward:
- When clicking a result tab, the editor now displays the query that produced those results

---

This PR was created by the /issue-triage command.