### PR TITLE
fix: use Monaco defineTheme API for custom background colors

### DIFF
--- a/src/components/monaco-editor/monaco-editor.js
+++ b/src/components/monaco-editor/monaco-editor.js
@@ -9,8 +9,40 @@ window.addEventListener('unhandledrejection', (event) => {
     }
 });
 
+// Define custom themes that read from CSS variables
+function defineCustomThemes() {
+    // Get computed styles to read CSS variable values
+    const styles = getComputedStyle(document.documentElement);
+    const navBg = styles.getPropertyValue('--nav-bg').trim();
+
+    // Define custom light theme
+    monaco.editor.defineTheme('sftools-light', {
+        base: 'vs',
+        inherit: true,
+        rules: [],
+        colors: {
+            'editor.background': navBg,
+            'editorGutter.background': navBg
+        }
+    });
+
+    // Define custom dark theme
+    monaco.editor.defineTheme('sftools-dark', {
+        base: 'vs-dark',
+        inherit: true,
+        rules: [],
+        colors: {
+            'editor.background': navBg,
+            'editorGutter.background': navBg
+        }
+    });
+}
+
+// Initialize custom themes on first load
+defineCustomThemes();
+
 function getMonacoTheme() {
-    return document.documentElement.getAttribute('data-theme') === 'dark' ? 'vs-dark' : 'vs';
+    return document.documentElement.getAttribute('data-theme') === 'dark' ? 'sftools-dark' : 'sftools-light';
 }
 
 const defaultOptions = {
@@ -97,6 +129,8 @@ class MonacoEditor extends HTMLElement {
 
     updateEditorTheme() {
         if (this.editor) {
+            // Redefine themes with current CSS variable values
+            defineCustomThemes();
             monaco.editor.setTheme(getMonacoTheme());
         }
     }


### PR DESCRIPTION
The previous approach of adding CSS variables to style.css didn't work because Monaco Editor doesn't automatically read CSS variables.

This fix:
- Defines custom themes (sftools-light/sftools-dark) using Monaco's defineTheme() API
- Reads --nav-bg CSS variable at runtime using getComputedStyle()
- Overrides editor.background and editorGutter.background colors
- Redefines themes when app theme changes to pick up new CSS values

Fixes #64

Generated with [Claude Code](https://claude.ai/code)