### PR TITLE
fix: enable horizontal scrolling for query tabs

### DIFF
--- a/src/components/query/QueryTab.module.css
+++ b/src/components/query/QueryTab.module.css
@@ -87,13 +87,13 @@
 
 .tabs {
     display: flex;
-    flex-wrap: wrap;
     gap: 2px;
     padding: 10px 15px;
     background-color: var(--card-header-bg);
     border-bottom: 1px solid var(--border-color);
     min-height: 40px;
     align-items: center;
+    overflow-x: auto;
 }
 
 .tabsEmpty {


### PR DESCRIPTION
## Summary
Enables horizontal scrolling for query tabs instead of wrapping to multiple rows.

## Changes
- Modified `src/components/query/QueryTab.module.css`
  - Removed `flex-wrap: wrap;` from `.tabs` class
  - Added `overflow-x: auto;` for horizontal scrolling

## Testing
With many query tabs open, the tabs container now scrolls horizontally instead of wrapping to multiple rows, providing a cleaner UX.

Fixes #80

---
Generated with [Claude Code](https://claude.ai/code)