### PR TITLE
Improve history modal UI (fixes #76)

### DIFF
--- a/src/components/apex/ApexTab.module.css
+++ b/src/components/apex/ApexTab.module.css
@@ -38,7 +38,7 @@
 
 .historyModal {
     width: 300px;
-    max-height: 400px;
+    height: 340px;
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -55,6 +55,8 @@
     padding: 8px 12px;
     background: transparent;
     border: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
     color: var(--text-muted);
     cursor: pointer;
     font-size: 13px;
@@ -68,8 +70,7 @@
 
 .dropdownTab.active {
     color: var(--primary-color);
-    border-bottom: 2px solid var(--primary-color);
-    margin-bottom: -1px;
+    border-bottom-color: var(--primary-color);
 }
 
 .dropdownContent {

--- a/src/components/query/QueryTab.module.css
+++ b/src/components/query/QueryTab.module.css
@@ -32,7 +32,7 @@
 
 .historyModal {
     width: 320px;
-    max-height: 400px;
+    height: 340px;
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -53,6 +53,8 @@
     padding: 10px 16px;
     background: transparent;
     border: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
     font-size: 13px;
     font-weight: 500;
     color: var(--text-muted);
@@ -67,8 +69,7 @@
 
 .dropdownTabActive {
     color: var(--primary-color);
-    border-bottom: 2px solid var(--primary-color);
-    margin-bottom: -1px;
+    border-bottom-color: var(--primary-color);
 }
 
 .dropdownContent {

--- a/src/components/script-list/ScriptList.module.css
+++ b/src/components/script-list/ScriptList.module.css
@@ -20,6 +20,11 @@
     padding: 10px 16px;
     cursor: pointer;
     transition: background 0.15s;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.scriptItem:last-child {
+    border-bottom: none;
 }
 
 .scriptItem:hover {

--- a/src/components/script-list/ScriptList.tsx
+++ b/src/components/script-list/ScriptList.tsx
@@ -75,14 +75,6 @@ export function HistoryList<T extends HistoryEntry>({
               <div className={styles.scriptActions}>
                 <button
                   className={styles.scriptAction}
-                  title="Load"
-                  onClick={(e) => handleLoad(content, e)}
-                  data-testid="script-action-load"
-                >
-                  &#8629;
-                </button>
-                <button
-                  className={styles.scriptAction}
                   title="Add to favorites"
                   onClick={(e) => handleFavorite(content, e)}
                   data-testid="script-action-favorite"
@@ -161,14 +153,6 @@ export function FavoritesList<T extends FavoriteEntry>({
             <div className={styles.scriptMeta}>
               <span>{formatTime(item.timestamp)}</span>
               <div className={styles.scriptActions}>
-                <button
-                  className={styles.scriptAction}
-                  title="Load"
-                  onClick={(e) => handleLoad(content, e)}
-                  data-testid="script-action-load"
-                >
-                  &#8629;
-                </button>
                 <button
                   className={styles.scriptAction}
                   title="Delete"


### PR DESCRIPTION
## Summary
- Remove redundant "Load" button from history/favorites lists (clicking the row already loads)
- Add visual separation between list items with border dividers
- Set consistent fixed height for modal (no longer resizes based on entry count)
- Fix tab underline flicker when switching between History/Favorites

Fixes #76

## Test plan
- [x] Build passes
- [x] Frontend tests pass for query-history and apex-history