### PR TITLE
Fix input and editor border visibility in light mode

### DIFF
--- a/src/components/monaco-editor/MonacoEditor.module.css
+++ b/src/components/monaco-editor/MonacoEditor.module.css
@@ -5,6 +5,9 @@
     position: relative;
     width: 100%;
     height: 200px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    overflow: hidden;
 }
 
 /* Resize handle at bottom of editor */

--- a/src/style.css
+++ b/src/style.css
@@ -6,7 +6,7 @@
     --card-bg: #ffffff;
     --text-main: #16325c;
     --text-muted: #54698d;
-    --border-color: #dddbda;
+    --border-color: #c9c7c5;
     --nav-bg: #ffffff;
 
     /* Extended palette */


### PR DESCRIPTION
## Summary
- Darkened light mode border color from `#dddbda` to `#c9c7c5` for better contrast against white backgrounds
- Added visible borders to Monaco editor containers (REST response section and other code editors)
- Improves visibility of input fields and editor boundaries in light mode

Fixes #74

## Test plan
- [x] Build completes successfully
- [x] All 890 unit tests pass
- [x] TypeScript, lint, and format checks pass
- [ ] Manual verification: Load extension in light mode and verify inputs and REST response section have visible borders