### PR TITLE
Fix /workflow command from first-use learnings

### DIFF
--- a/.claude/commands/workflow.md
+++ b/.claude/commands/workflow.md
@@ -40,6 +40,7 @@ gh issue view <number>
 
 ```bash
 git checkout main
+git pull origin main
 git checkout -b <branch-name>
 ```
 


### PR DESCRIPTION
## Summary

- **Branch from main**: Always switch to main before creating a new branch to avoid carrying unrelated commits
- **Use Task tool for implementation**: Dispatch to senior-dev subagent instead of using Skill tool (which only loads instructions into the conversation without doing work)
- **Stage OpenSpec artifacts**: New Step 8.5 stages `openspec/changes/<name>/` so planning artifacts are included in commits and PRs
- **Add missing permissions**: Added `git add`, `git stash`, `Skill(commit)`, `Skill(pr)` to allowed-tools

## Test plan

- [ ] Run `/workflow` on a new task and verify it creates a branch from main
- [ ] Verify implementation dispatches to a subagent instead of loading skill instructions
- [ ] Verify OpenSpec artifacts are staged before commit step